### PR TITLE
V3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,63 @@
-# pixiv_crawler_urllib
-这是使用`Python@3.8`编写的的高效爬虫。
+# PixivCrawler
+这是使用`Python@3.10`编写的的高效爬虫。
 
 
 - 推荐使用最新版本的软件，以避免发生无法预期的错误 
-- 本程序(pixiv_crawler)仅供学习交流，最初目的达成后请自行删除，请勿用于商业用途 
+- 本程序(PixivCrawler)仅供学习交流，最初目的达成后请自行删除，请勿用于商业用途 
 - 使用后任何不可知事件都与原作者无关，原作者不承担任何后果 
-- 请使用V2Ray版本<=4.31.0（注意），`Shadowsocks`类型，代理`pac`模式进行连接
-- main.py使用`urllib`下载，较不稳定。推荐使用_main.py下载插画链接后使用其他下载软件（如`IDM`）下载
-- 短时间内大量的请求可能导致IP被短时间封禁，望知悉
+- 建议使用稳定的梯子，使用V2RayN或Clash for Windows客户端，具体事宜在使用说明具体介绍
+- 短时大量请求可能导致IP被短时间封禁，望知悉
 
 
-### 使用
+## 使用
+### 一、运行环境
+- Python 3.10
+- （建议）Visual Studio Code
+- Windows 10/11
 
-1.安装第三方库
+### 二、第三方库
 ```
+(cmd)
 pip install requests
-pip install urllib
-pip install pyperclip
+pip install tqdm
+pip install urllib3
 ```
 
-2.打开main.py
-- 输入你的cookies(位于(Chrome内核浏览器)F12->应用->Cookie-> " https://www.pixiv.net ")（注意保护隐私信息）
-- 输入下载线程数（默认为5）
+### 三、配置设置
+`config`为程序设置(ln: 216)
+- 必选项: cookies, proxies
+- 剩余为可选项
+- P.S. 代理设置请根据自己客户端的实际情况而定，端口可能会有所改动  `example: 127.0.0.1:xxxx`
+```
+#------------config------------
+#禁用InsecureRequestWarning
+urllib3.disable_warnings(urllib3.connectionpool.InsecureRequestWarning)
+#你的用户cookie
+cookie = ''
 
-3.运行软件
+##代理设置
+#(若使用V2Ray，请用 # 注释Clash for windows相关代理，取消V2Ray的注释)
+
+# V2Ray
+#proxies = {
+#    'http': '127.0.0.1:10809',
+#    'https': '127.0.0.1:10809'
+#}
+
+# Clash for windows
+proxies = {
+    'http': '127.0.0.1:7890',
+    'https': '127.0.0.1:7890'
+}
+#下载文件的保存位置
+download_path = os.getcwd() + '.\\Downloads\\'
+#网页端解析插画链接的线程数
+analysis_thread_num = 5
+#下载线程数
+download_thread_num = 3
+#每次下载的分块
+chunk_size = 1024
+#重试次数
+times = 5
+#------------config------------
+```

--- a/demo/debug.py
+++ b/demo/debug.py
@@ -1,0 +1,11 @@
+
+import requests
+
+proxies = {
+    'http': '127.0.0.1:7890',
+    'https': '127.0.0.1:7890'
+}
+headers = {'referer': 'https://www.pixiv.net'}
+html = requests.get(url= ' https://i.pximg.net/img-original/img/2015/11/11/22/37/04/53503407_p0.jpg',proxies=proxies,headers = headers)
+{'Server': 'nginx', 'Date': 'Mon, 27 Jun 2022 03:50:13 GMT', 'Content-Type': 'image/jpeg', 'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'Cache-Control': 'max-age=31536000', 'Expires': 'Tue, 27 Jun 2023 03:50:13 GMT', 'Last-Modified': 'Sat, 17 Dec 2016 15:00:13 GMT', 'X-Content-Type-Options': 'nosniff', 'Age': '0', 'Via': 'http/1.1 f011 (second)'}
+{'Server': 'nginx', 'Date': 'Mon, 27 Jun 2022 04:15:16 GMT', 'Content-Type': 'image/jpeg', 'Content-Length': '1051590', 'Connection': 'keep-alive', 'Cache-Control': 'max-age=31536000', 'Expires': 'Tue, 27 Jun 2023 04:07:47 GMT', 'Last-Modified': 'Wed, 11 Nov 2015 13:37:05 GMT', 'X-Content-Type-Options': 'nosniff', 'Age': '310', 'Via': 'http/1.1 f004 (second)', 'Accept-Ranges': 'bytes'}

--- a/demo/downloader.py
+++ b/demo/downloader.py
@@ -1,0 +1,32 @@
+import time
+import requests
+from tqdm import tqdm
+import os
+
+def Down():
+    s = requests.session()
+    chunk_size = 1024 # 每次下载数据区块大小(B)
+    res = s.get(
+        url = 'https://i.pximg.net/img-original/img/2021/12/08/11/57/01/94641543_p0.jpg', 
+        headers = {'referer': 'https://www.pixiv.net'}, 
+        #proxies={'http': '127.0.0.1:10809','https': '127.0.0.1:10809'}, #v2ray
+        proxies={'http': '127.0.0.1:7890','https': '127.0.0.1:7890'},#clash
+        stream=True)
+    content_size = int(res.headers['content-length'])
+    content_size_ = content_size // 1024
+    it = res.iter_content(chunk_size = chunk_size)
+    with open('test.jpg', 'wb') as f:
+        for chunk in tqdm(
+            iterable=it,
+            total=content_size_,
+            unit='KB',
+            desc=None,
+            leave=False
+            ):
+
+            f.write(chunk)
+        f.close()
+
+    #确保文件被完整下载
+    local_file_size = list(os.stat('test.jpg'))[6]
+

--- a/demo/headers_test.py
+++ b/demo/headers_test.py
@@ -1,0 +1,23 @@
+raw = """
+:authority: www.pixiv.net
+:method: GET
+:path: /ajax/user/4405891/profile/all?lang=zh
+:scheme: https
+accept: application/json
+accept-encoding: gzip, deflate, br
+accept-language: zh-CN,zh;q=0.9,ja;q=0.8,en;q=0.7,en-US;q=0.6
+cookie: first_visit_datetime_pc=2022-01-03+13%3A15%3A32; p_ab_id=6; p_ab_id_2=0; p_ab_d_id=1472835414; yuid_b=QEmAJ2I; privacy_policy_agreement=3; c_type=22; privacy_policy_notification=0; a_type=0; b_type=1; login_ever=yes; __utmv=235335808.|2=login%20ever=yes=1^3=plan=normal=1^5=gender=male=1^6=user_id=71963925=1^9=p_ab_id=6=1^10=p_ab_id_2=0=1^11=lang=zh=1; PHPSESSID=71963925_2UK0nnz2gOuCOJM24va7PZLsOZZukXvx; device_token=09a4ab004ad51c02f7d70cd321cce048; __utmz=235335808.1655889206.115.5.utmcsr=accounts.pixiv.net|utmccn=(referral)|utmcmd=referral|utmcct=/; QSI_S_ZN_5hF4My7Ad6VNNAi=v:0:0; __cf_bm=xnT.Q_v5mVa0XPLLYLZVLqbl8oE.qcPjL_Cw_MUEZUQ-1656238091-0-AQ5QOCt54+RIUssD/j8Kkax0s3fqSvcOYcqR8roOBGEYQKnjQLA3ZlaGt2V8ERTLsNxVJy+x1ybZxw2Bw7X1d4CN+sG+XLnQ1MTv3m2/zjgnp6QJhZmp+P7U8t5sEm7TkwBaa11x0sh7KLKTy8jwK/y44DLjgm8owJwE14p+MYAMV6pWLG/7KogYr8noo2/TDQ==; __utmc=235335808; _ga=GA1.2.118181462.1641183337; _gid=GA1.2.1166170450.1656238608; tag_view_ranking=RTJMXD26Ak~uusOs0ipBx~9ODMAZ0ebV~Lt-oEicbBr~jhuUT0OJva~LJo91uBPz4~KvAGITxIxH~RNN9CgGExV~K8esoIs2eW~r0q4yFTWtg~BSkdEJ73Ii~QLvl6kE4lC~D0nMcn6oGk~vLP3DMasD_~75zhzbk0bS~2bq8SNVWly~eVxus64GZU~cFYMvUloX0~4QveACRzn3~FgXjOGAbwK~VLDgZNuX1x~VSI71mhgdM~nQRrj5c6w_~Xs-7j6fVPs~Cc23GhmKNc~GX7J0_CPTv~Mg6bq-SpX8~PwDMGzD6xn~mFW848gK6h~pa4LoD4xuT~LVSDGaCAdn~jH0uD88V6F~ETjPkL0e6r~v7Qz4joCBq~sb_gmFpDzp~-sp-9oh8uv~kGYw4gQ11Z~lH5YZxnbfC~BtXd1-LPRH~Itu6dbmwxu~t2ErccCFR9~jyw53VSia0~2pZ4K1syEF~1Xn1rApx2-~hW_oUTwHGx~qWFESUmfEs~G04tXVOkHP~_pwIgrV8TB~0xsDLqCEW6~aKhT3n4RHZ~vSWEvTeZc6~E9anU9DdS_~OOsvVvWvg6~HLWLeyYOUF~zASPXsXKdt~v6KNtCPEKI~CrFcrMFJzz~Ptpn09xujs~nRp2ZLPLbj~4ZEPYJhfGu~KkXUHnIeIl~66pgV3BU1a~TV3I2h_Vd8~gzY20gtW1F~ykNnpw2uh5; _ga_75BBYNYN9J=GS1.1.1656238578.3.1.1656238617.0; __utma=235335808.118181462.1641183337.1656238620.1656238620.153
+dnt: 1
+referer: https://www.pixiv.net/users/4405891/illustrations?p=1
+sec-ch-ua: " Not A;Brand";v="99", "Chromium";v="102", "Google Chrome";v="102"
+sec-ch-ua-mobile: ?0
+sec-ch-ua-platform: "Windows"
+sec-fetch-dest: empty
+sec-fetch-mode: cors
+sec-fetch-site: same-origin
+user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36
+x-kl-ajax-request: Ajax_Request
+x-user-id: 71963925
+"""
+
+print(raw.split(': '))

--- a/demo/ostest.py
+++ b/demo/ostest.py
@@ -1,0 +1,2 @@
+import os
+st = list(os.stat('test.jpg'))[6]

--- a/demo/re_test.py
+++ b/demo/re_test.py
@@ -1,0 +1,4 @@
+import re
+
+str_to_del = re.findall(re.compile(r'\_p+(.*?)\.+'), 'https://i.pximg.net/img-original/img/2021/12/08/11/57/01/94641543_p0.jpg')
+print(str_to_del)

--- a/demo/soup_test.py
+++ b/demo/soup_test.py
@@ -1,0 +1,38 @@
+
+from bs4 import BeautifulSoup
+import requests
+
+illustrator_id = '4405891'
+
+cookie = 'first_visit_datetime_pc=2022-01-03+13%3A15%3A32; p_ab_id=6; p_ab_id_2=0; p_ab_d_id=1472835414; yuid_b=QEmAJ2I; privacy_policy_agreement=3; c_type=22; privacy_policy_notification=0; a_type=0; b_type=1; login_ever=yes; __utmv=235335808.|2=login%20ever=yes=1^3=plan=normal=1^5=gender=male=1^6=user_id=71963925=1^9=p_ab_id=6=1^10=p_ab_id_2=0=1^11=lang=zh=1; PHPSESSID=71963925_2UK0nnz2gOuCOJM24va7PZLsOZZukXvx; device_token=09a4ab004ad51c02f7d70cd321cce048; __utmz=235335808.1655889206.115.5.utmcsr=accounts.pixiv.net|utmccn=(referral)|utmcmd=referral|utmcct=/; QSI_S_ZN_5hF4My7Ad6VNNAi=v:0:0; __cf_bm=xnT.Q_v5mVa0XPLLYLZVLqbl8oE.qcPjL_Cw_MUEZUQ-1656238091-0-AQ5QOCt54+RIUssD/j8Kkax0s3fqSvcOYcqR8roOBGEYQKnjQLA3ZlaGt2V8ERTLsNxVJy+x1ybZxw2Bw7X1d4CN+sG+XLnQ1MTv3m2/zjgnp6QJhZmp+P7U8t5sEm7TkwBaa11x0sh7KLKTy8jwK/y44DLjgm8owJwE14p+MYAMV6pWLG/7KogYr8noo2/TDQ==; __utmc=235335808; _ga=GA1.2.118181462.1641183337; _gid=GA1.2.1166170450.1656238608; tag_view_ranking=RTJMXD26Ak~uusOs0ipBx~9ODMAZ0ebV~Lt-oEicbBr~jhuUT0OJva~LJo91uBPz4~KvAGITxIxH~RNN9CgGExV~K8esoIs2eW~r0q4yFTWtg~BSkdEJ73Ii~QLvl6kE4lC~D0nMcn6oGk~vLP3DMasD_~75zhzbk0bS~2bq8SNVWly~eVxus64GZU~cFYMvUloX0~4QveACRzn3~FgXjOGAbwK~VLDgZNuX1x~VSI71mhgdM~nQRrj5c6w_~Xs-7j6fVPs~Cc23GhmKNc~GX7J0_CPTv~Mg6bq-SpX8~PwDMGzD6xn~mFW848gK6h~pa4LoD4xuT~LVSDGaCAdn~jH0uD88V6F~ETjPkL0e6r~v7Qz4joCBq~sb_gmFpDzp~-sp-9oh8uv~kGYw4gQ11Z~lH5YZxnbfC~BtXd1-LPRH~Itu6dbmwxu~t2ErccCFR9~jyw53VSia0~2pZ4K1syEF~1Xn1rApx2-~hW_oUTwHGx~qWFESUmfEs~G04tXVOkHP~_pwIgrV8TB~0xsDLqCEW6~aKhT3n4RHZ~vSWEvTeZc6~E9anU9DdS_~OOsvVvWvg6~HLWLeyYOUF~zASPXsXKdt~v6KNtCPEKI~CrFcrMFJzz~Ptpn09xujs~nRp2ZLPLbj~4ZEPYJhfGu~KkXUHnIeIl~66pgV3BU1a~TV3I2h_Vd8~gzY20gtW1F~ykNnpw2uh5; _ga_75BBYNYN9J=GS1.1.1656238578.3.1.1656238617.0; __utma=235335808.118181462.1641183337.1656238620.1656238620.153'
+proxies = {
+    'http': '127.0.0.1:10809',
+    'https': '127.0.0.1:10809'
+}
+ref = '94641543'
+
+andr_headers = {
+    'accept': 'application/json',
+    'accept-encoding': 'gzip, deflate, br',
+    'accept-language': 'zh-CN,zh;q=0.9,ja;q=0.8,en;q=0.7,en-US;q=0.6',
+    'cookie': cookie,
+    'dnt': '1',
+    'referer': 'https://www.pixiv.net/artworks/'+ ref,
+    'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="102", "Google Chrome";v="102"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"Windows"',
+    'sec-fetch-dest': 'empty',
+    'sec-fetch-mode': 'cors',
+    'sec-fetch-site': 'same-origin',
+    'user-agent': 'Mozilla/5.0 (Linux; Android 8.0.0; FRD-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.85 Mobile Safari/537.36',
+    'x-kl-ajax-request': 'Ajax_Request',
+    'x-user-id': '71963925'
+}
+html = requests.get(url='https://www.pixiv.net/artworks/94641543#big_0',headers=andr_headers,proxies=proxies).content.decode('utf-8')
+
+soup = BeautifulSoup(html,'lxml')
+with open('html.txt', 'w',encoding = 'utf-8') as f:
+    f.write(html)
+    f.close()
+#data = soup.select('.illust-details-big')
+

--- a/main.py
+++ b/main.py
@@ -10,7 +10,10 @@
 # v1.0: 程序首个版本
 # v1.1: 增加下载pixiv限制内容的功能(修改用户headers:请在模块Web.geturl_threads中的geturl类__init__函数中添加你的headers(全部))
 # v2.0-Beta: null
-# v3.0
+# v3.0: 重建所有下载功能，增加进度条显示，增强代码执行效率
+# 
+# 
+
 
 import json
 import os

--- a/main.py
+++ b/main.py
@@ -1,0 +1,298 @@
+# Author: zch9241 <github.com/zch9241><zch2426936965@gmail.com>
+# 
+# License: Apache-2.0 license
+# 
+# version: 3.0
+# 
+# 版权声明: 该软件(PixivCrawler)为「Author」所有，转载请附上本声明。保留所有权利。
+# 
+# 版本更新说明：
+# v1.0: 程序首个版本
+# v1.1: 增加下载pixiv限制内容的功能(修改用户headers:请在模块Web.geturl_threads中的geturl类__init__函数中添加你的headers(全部))
+# v2.0-Beta: null
+# v3.0
+
+import json
+import os
+import re
+import threading
+import time
+
+import requests
+import urllib3
+from tqdm import tqdm
+
+
+def GetAllPages():
+    illust_url_alllangzh = 'https://www.pixiv.net/ajax/user/' + illustrator_id + '/profile/all?lang=zh'
+    #https://www.pixiv.net/ajax/user/4405891/profile/all?lang=zh
+    html = requests.get(url = illust_url_alllangzh, headers = win_headers, proxies = proxies, verify = False).content.decode('utf-8')
+    s = list(json.loads(html)['body']['illusts'].keys())
+
+    print('[GetAllPages(function)]: info: 成功获取插画详情页链接 长度: {}'.format(len(s)))
+    return s
+
+def GetUserName():
+    global AllPages
+    global proxies
+    global illustrator_id
+
+    andr_headers = {
+        'accept': 'application/json',
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'zh-CN,zh;q=0.9,ja;q=0.8,en;q=0.7,en-US;q=0.6',
+        'cookie': cookie,
+        'dnt': '1',
+        'referer': 'https://www.pixiv.net/artworks/'+ AllPages[0],
+        'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="102", "Google Chrome";v="102"',
+        'sec-ch-ua-mobile': '?0',
+        'sec-ch-ua-platform': '"Windows"',
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'same-origin',
+        'user-agent': 'Mozilla/5.0 (Linux; Android 8.0.0; FRD-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.85 Mobile Safari/537.36',
+        'x-kl-ajax-request': 'Ajax_Request',
+        'x-user-id': '71963925'
+    }
+
+    user_url = 'https://www.pixiv.net/touch/ajax/illust/details?illust_id=' + AllPages[0] + '&ref=&lang=zh'
+    html = requests.get(url = user_url, headers = andr_headers, proxies = proxies, verify = False).content.decode('utf-8')
+    name = json.loads(html)['body']['author_details']['user_name']
+    Name = name + '({})'.format(illustrator_id)
+    return Name
+
+
+def GetAllPagePicUrl():
+    global AllPages
+    global AllOrgPicUrlList
+    global proxies
+
+    s = requests.session()
+
+    while len(AllPages) > 0:
+        pageurl = AllPages.pop()
+        andr_headers = {
+        'accept': 'application/json',
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'zh-CN,zh;q=0.9,ja;q=0.8,en;q=0.7,en-US;q=0.6',
+        'cookie': cookie,
+        'dnt': '1',
+        'referer': 'https://www.pixiv.net/artworks/'+ pageurl,
+        'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="102", "Google Chrome";v="102"',
+        'sec-ch-ua-mobile': '?0',
+        'sec-ch-ua-platform': '"Windows"',
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'same-origin',
+        'user-agent': 'Mozilla/5.0 (Linux; Android 8.0.0; FRD-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.85 Mobile Safari/537.36',
+        'x-kl-ajax-request': 'Ajax_Request',
+        'x-user-id': '71963925'
+        }
+
+        html_ = s.get('https://www.pixiv.net/touch/ajax/illust/details?illust_id=' + pageurl + '&ref=&lang=zh', headers = andr_headers, proxies = proxies, verify = False).content.decode('utf-8')
+        #html_ = requests.get('https://www.pixiv.net/touch/ajax/illust/details?illust_id=94641543&ref=&lang=zh', headers = andr_headers, proxies = proxies).content.decode('utf-8')
+        picnum = int(json.loads(html_)['body']['illust_details']['page_count'])
+        first_org_pic_url = str(json.loads(html_)['body']['illust_details']['url_big'])
+        #https://i.pximg.net/img-original/img/2021/12/08/11/57/01/94641543_p0.jpg
+        first_picname = first_org_pic_url.split('/')[-1]
+        left_str = first_org_pic_url.replace(first_picname, '')
+
+
+        AllOrgPicUrlList.append(first_org_pic_url)
+
+        for i in range(1, picnum):
+            str_to_del = re.findall(re.compile(r'\_p+(.*?)\.+'), first_picname)[0]
+            pic_name = first_picname.replace(str_to_del, str(i))
+            AllOrgPicUrlList.append(left_str + pic_name)
+
+def Downloader():
+    global AllOrgPicUrlList
+    global DownloadFailedUrl
+    global proxies
+    global user_path
+    global chunk_size
+    global times
+
+    s = requests.session()
+    ThreadName = threading.current_thread().name
+
+    def main_downloader(downloadurl):
+        current_len = len(AllOrgPicUrlList)
+        filename = downloadurl.split('/')[-1]
+        filedownload_path = user_path + filename
+
+        def key():
+            """
+            验证响应头中是否存在'content-length'字段
+            """
+            for _ in range(times):
+                response = s.get(
+                url = downloadurl, 
+                headers = {
+                    'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+                    'accept-encoding': 'gzip, deflate, br',
+                    'accept-language': 'zh-CN,zh;q=0.9,ja;q=0.8,en;q=0.7,en-US;q=0.6',
+                    'cache-control': 'max-age=0',
+                    'dnt': '1',
+                    'referer': 'https://www.pixiv.net',
+                    'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="102", "Google Chrome";v="102"',
+                    'sec-ch-ua-mobile': '?0',
+                    'sec-ch-ua-platform': '"Windows"',
+                    'sec-fetch-dest': 'document',
+                    'sec-fetch-mode': 'navigate',
+                    'sec-fetch-site': 'none',
+                    'sec-fetch-user': '?1',
+                    'upgrade-insecure-requests': '1',
+                    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36'
+                    }, 
+                proxies = proxies,
+                stream = True,
+                verify = False    #ProxyError
+                )
+                try:
+                    response.headers['content-length']
+                    break
+                except KeyError:
+                    time.sleep(5)
+                    print('[Downloader-main-key(function)]: warn: 不存在content-length键。重试。 请求: {}'.format(downloadurl))
+                    continue
+                
+            return response
+        
+        response = key()
+        content_size = int(response.headers['content-length'])
+            
+        content_size_ = content_size // 1024
+        it = response.iter_content(chunk_size = chunk_size)
+        with open(filedownload_path, 'wb') as f:
+            bar = tqdm(
+                iterable=it,
+                total=content_size_,
+                colour = 'blue',
+                unit='KB',
+                leave=False
+                )
+            for chunk in bar:
+                bar.set_description('{} 正在下载 {} ,还剩 {} '.format(ThreadName, filename, current_len))
+                f.write(chunk)
+            f.close()
+
+        #确保文件被完整下载
+        local_file_size = list(os.stat(filedownload_path))[6]
+        if local_file_size < content_size:
+            DownloadFailedUrl.append(downloadurl)
+            print('[Downloader-main(function)]: warn: {} 未完全下载 ({} / {})'.format(filename, local_file_size, content_size))
+        local_file_size = 0
+
+
+    while len(AllOrgPicUrlList) > 0:
+        url = AllOrgPicUrlList.pop()
+        main_downloader(downloadurl = url)
+
+    while len(DownloadFailedUrl) > 0:
+        url_ = DownloadFailedUrl.pop()
+        main_downloader(downloadurl = url_)
+
+    s.close()
+
+
+
+class jutils():
+    def mk_download_path(path):
+        try:
+            os.mkdir(path)
+        except FileExistsError:
+            pass
+    def mk_user_path(name):
+        try:
+            os.mkdir(download_path + name)
+        except FileExistsError:
+            pass
+        user_path = download_path + name + '\\'
+        return user_path
+
+
+if __name__ == '__main__':
+    #------------config------------
+    #禁用InsecureRequestWarning
+    urllib3.disable_warnings(urllib3.connectionpool.InsecureRequestWarning)
+    #你的用户cookie
+    cookie = ''
+
+    ##代理设置
+    #(若使用V2Ray，请用 # 注释Clash for windows相关代理，取消V2Ray的注释)
+
+    # V2Ray
+    #proxies = {
+    #    'http': '127.0.0.1:10809',
+    #    'https': '127.0.0.1:10809'
+    #}
+
+    # Clash for windows
+    proxies = {
+        'http': '127.0.0.1:7890',
+        'https': '127.0.0.1:7890'
+    }
+    #下载文件的保存位置
+    download_path = os.getcwd() + '.\\Downloads\\'
+    #网页端解析插画链接的线程数
+    analysis_thread_num = 5
+    #下载线程数
+    download_thread_num = 3
+    #每次下载的分块
+    chunk_size = 1024
+    #重试次数
+    times = 5
+    #------------config------------
+
+    AllOrgPicUrlList = []
+    DownloadFailedUrl = []
+    analysis_thread_list = []
+    download_thread_list = []
+
+    #illustrator_id = '219976'
+    illustrator_id = str(input('[main(input)]: 请输入画师id(仅需int类型): '))
+    win_headers = {
+        'accept': 'application/json',
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'zh-CN,zh;q=0.9,ja;q=0.8,en;q=0.7,en-US;q=0.6',
+        'cookie': cookie,
+        'dnt': '1',
+        'referer': 'https://www.pixiv.net/users/' + illustrator_id + '/illustrations?p=1',
+        'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="102", "Google Chrome";v="102"',
+        'sec-ch-ua-mobile': '?0',
+        'sec-ch-ua-platform': '"Windows"',
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'same-origin',
+        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36',
+        'x-kl-ajax-request': 'Ajax_Request',
+        'x-user-id': '71963925'
+    }
+
+    jutils.mk_download_path(path = download_path)
+
+    AllPages = GetAllPages()
+    user_path = jutils.mk_user_path(name = GetUserName())
+
+    for th in range(analysis_thread_num):
+        th = threading.Thread(target = GetAllPagePicUrl)
+        analysis_thread_list.append(th)
+    for a in analysis_thread_list:
+        a.start()
+    for b in analysis_thread_list:
+        b.join()
+    
+
+    for th_ in range(download_thread_num):
+        th_ = threading.Thread(target = Downloader)
+        download_thread_list.append(th_)
+    for c in download_thread_list:
+        c.start()
+    for d in download_thread_list:
+        d.join()
+
+    print('[main]: info: 所有插画下载完成...总耗时')
+
+    os.system('pause')
+


### PR DESCRIPTION
- 这次将`urllib`改成了`requests`，没有分析网页元素（没办法，pixiv现在貌似通过其他方式加载元素），所以就全部通过爬取接口来实现下载功能了。比上次鸡肋的获取图片链接还是要好的嘛（小声）